### PR TITLE
Remove lemon from recipes: reduce accutance.

### DIFF
--- a/film/BW/normal_dev.md
+++ b/film/BW/normal_dev.md
@@ -75,7 +75,7 @@ Theses formulas and devs times are for normal dev process:
 
 
 ### Stop
-  * Water + 2ml lemon juice: more or less 10 to 30 secondes
+  * Water: more or less 10 to 30 secondes
 
 ### Fix
   * Ilford Rapid fixer 1+4: not less than 5 and no more than 15 minutes.

--- a/film/BW/stand_dev.md
+++ b/film/BW/stand_dev.md
@@ -56,7 +56,7 @@ Developper formula dilution:
 
 #### Stop
 
- * Water + 2ml lemon juice: more or less 10 to 30 secondes.
+ * Water: more or less 10 to 30 secondes.
 
 #### Fix
 

--- a/paper/BW/RC.md
+++ b/paper/BW/RC.md
@@ -5,7 +5,7 @@
   * Dev:
     * Tetenal eukobrom : 1+9 @ 20° (manual deals about 60 to 90 seconds as dev time)
     * Ilford PQ : 1+9 @ 20° (manual deals about 60 seconds as dev time)
-  * Water + 2ml lemon juice
+  * Water
   * Fix: same as film.
 
   * Notes about quantities : 1 liter for format less than 24x30 is ok... 2 liter for 24x30 better


### PR DESCRIPTION
# Description 📖 

Water did not stop developer immediatly. That reduction about action is more progressive and from some sources that helps to get mor accutance (less blur).